### PR TITLE
Rgba2gray fixes

### DIFF
--- a/examples/rgba2gray.rs
+++ b/examples/rgba2gray.rs
@@ -29,7 +29,7 @@ fn main() {
 }
 
 fn run(ptx: &str, img: &RgbaImage) -> Result<()> {
-    const GRID_SIZE: u32 = 32;
+    const BLOCK_SIZE: u32 = 32;
 
     let h_rgba = img.as_ptr();
     let (w, h) = img.dimensions();
@@ -81,8 +81,8 @@ fn run(ptx: &str, img: &RgbaImage) -> Result<()> {
                   Any(&d_gray),
                   Any(&(w as i32)),
                   Any(&(h as i32))],
-                Grid::xy(GRID_SIZE, GRID_SIZE),
-                Block::xy((w - 1) / GRID_SIZE + 1, (h - 1) / GRID_SIZE + 1))?;
+                Grid::xy((w - 1) / BLOCK_SIZE + 1, (h - 1) / BLOCK_SIZE + 1),
+                Block::xy(BLOCK_SIZE, BLOCK_SIZE))?;
     let elapsed = now.elapsed();
     ds.push(elapsed);
     println!("    {:?} - Executing the kernel", elapsed);

--- a/examples/rgba2gray.rs
+++ b/examples/rgba2gray.rs
@@ -23,9 +23,9 @@ fn main() {
         .read_to_string(ptx)
         .unwrap();
 
-    let img = image::open(args.next().unwrap()).unwrap();
+    let img = image::open(args.next().unwrap()).unwrap().to_rgba();
 
-    run(ptx, img.as_rgba8().unwrap()).unwrap()
+    run(ptx, &img).unwrap()
 }
 
 fn run(ptx: &str, img: &RgbaImage) -> Result<()> {


### PR DESCRIPTION
These are two improvements to the "rgba2gray" example.

Loading an image larger than 1024x1024 causes a panic. The problem lies in this line:

```rust
Block::xy((w - 1) / GRID_SIZE + 1, (h - 1) / GRID_SIZE + 1))?;
```

The [CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#thread-hierarchy) states "On current GPUs, a thread block may contain up to 1024 threads". With large images, this code would try to create more than that. I fixed this by using a variable grid size and a constant block size, instead of the other way around.

The other improvement is supporting the loading of images without an alpha channel.